### PR TITLE
Fix issue with deprecated `warn` argument

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -30,8 +30,6 @@
 
 - name: Gather currently installed rpi_exporter version (if any)
   command: "/usr/local/bin/rpi_exporter --version"
-  args:
-    warn: false
   changed_when: false
   register: __rpi_exporter_current_version_output
   when: __rpi_exporter_is_installed.stat.exists


### PR DESCRIPTION
`warn` was deprecated in Ansible 2.11, and therefore this role breaks now. This PR removes that.